### PR TITLE
Add boto3 package via pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ ARG PIP_MODULES="\
     flake8==3.8.4 \
     molecule[docker]==3.2.1 \
     testinfra==6.0.0 \
+    boto3==1.18.46 \
     "
 
 RUN apk add --update --no-cache ${BUILD_DEPS} && \


### PR DESCRIPTION
Ansible roles that require modules for [AWS](https://github.com/ansible-collections/amazon.aws) for example aws_ssm lookup and the ec2 require [boto3](https://github.com/ansible-collections/amazon.aws#installing-this-collection) as a required dependency when executed.
Adding in the pip package boto3 (which also includes botocore) into the dockerfile