### PR TITLE
Add native Docker support + colors

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -66,3 +66,6 @@ inputs:
 runs:
   using: docker
   image: docker://gofrolist/molecule:v2
+  env:
+    ANSIBLE_ASYNC_DIR: "/tmp/.ansible_async"
+    ANSIBLE_FORCE_COLOR: "1"


### PR DESCRIPTION
This patch enforces color by default so the output looks nice in GitHub Actions.  Also, it sets `ANSIBLE_ASYNC_DIR` by default to a pre-set value or otherwise the Docker driver fails with this, it will make for a much better out-of-the-box experience with the action.