### PR TITLE
fix: set correct `molecule_working_dir`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -61,7 +61,7 @@ inputs:
       Path to another directory in the repository, where molecule command will be issued from.
       Useful in those cases where Ansible roles are not in git repository root.
     required: false
-    default: ${{ github.repository }}
+    default: ${{ github.workspace }}
 
 runs:
   using: docker


### PR DESCRIPTION
At the moment, the `molecule_working_dir` is set to the project which
causes an error when the action starts:

> /bin/sh: cd: line 1: can't cd to vexxhost/atmosphere: No such file or directory

This is because since the action runs inside a Docker container, it
takes the workspace and mounts it into `/github/workspace` and
exposes it.  Instead, this points to the correct folder which is the
workspace of the GitHub actions run.