### PR TITLE
bug: docker images don't use init system

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,9 +43,11 @@ ARG PACKAGES="\
     git \
     openssh-client \
     podman \
+    tini \
     "
 
 RUN apk add --update --no-cache ${PACKAGES} && \
     rm -rf /root/.cache
 
+ENTRYPOINT ["/sbin/tini", "--"]
 CMD cd ${INPUT_MOLECULE_WORKING_DIR}; molecule ${INPUT_MOLECULE_OPTIONS} ${INPUT_MOLECULE_COMMAND} ${INPUT_MOLECULE_ARGS}

--- a/Dockerfile.buster
+++ b/Dockerfile.buster
@@ -39,10 +39,12 @@ ARG PACKAGES="\
     git \
     openssh-client \
     podman \
+    tini \
     "
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -y ${PACKAGES} && \
     rm -rf /var/lib/apt/lists/*
 
+ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD cd ${INPUT_MOLECULE_WORKING_DIR}; molecule ${INPUT_MOLECULE_OPTIONS} ${INPUT_MOLECULE_COMMAND} ${INPUT_MOLECULE_ARGS}


### PR DESCRIPTION
At the moment, the images that are in-use do not actually have
any init system.  The problem with this is that Ansible will keep
spawning defunct processes that won't be getting cleaned up
and over a long Molecule run, it will simply crash / stop responding.

After 20 minutes of a Molecule run, you're up to 72 defunct
processes and it keeps counting.  This is an issue that was
also reported upstream inside Ansible and the resolution is
to use an init system (like tini)[1].

[1]: https://github.com/ansible/ansible/issues/49270#issuecomment-462440983