### PR TITLE
ci: fix trivy-action version ref (tag is v-prefixed)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,7 +139,7 @@ jobs:
           docker image ls -a
 
       - name: Run Trivy to check Docker image for vulnerabilities
-        uses: aquasecurity/trivy-action@0.36.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ${{ env.DOCKER_IMAGE_NAME }}:test
           format: sarif


### PR DESCRIPTION
The trivy-action git tag is `v0.36.0`, not `0.36.0` — the trivy-docker job in the Release workflow failed to resolve the action. Everything else in the release run succeeded (v2.8.0 was cut normally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QiyKFy88rBg6pYtz4WZ9rP