### PR TITLE
ci: only report fixable vulnerabilities in trivy scan

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,6 +145,7 @@ jobs:
           format: sarif
           output: trivy.sarif
           severity: MEDIUM,HIGH,CRITICAL
+          ignore-unfixed: true
 
       - name: Upload result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v4


### PR DESCRIPTION
Adds `ignore-unfixed: true` to the Trivy scan so only vulnerabilities with an available Debian fix are reported to Code Scanning. The current 347 open alerts are all unfixed base-image CVEs with no action available; they will auto-close on the next scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QiyKFy88rBg6pYtz4WZ9rP