### PR TITLE
fix: seed pip into the venv so runtime package installs work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,10 @@ WORKDIR /app
 COPY pyproject.toml uv.lock ./
 
 RUN --mount=type=cache,mode=0755,target=/root/.cache/uv \
-    uv sync --frozen --no-dev
+    uv sync --frozen --no-dev && \
+    # seed pip into the venv so users can install extra packages
+    # (pytest plugins, collection python deps) at runtime
+    uv pip install pip
 
 ##################
 # runtime


### PR DESCRIPTION
## Summary
Since the uv migration the image's venv has had no `pip` — the `pip` on PATH belonged to the system interpreter, so the README's documented workaround (installing extra Python packages / pytest plugins via a `shell` dependency step) silently installed into a site-packages that molecule and pytest never see. This seeds pip into the venv at build time (`uv pip install pip`), so runtime `pip install` lands where it's used.

Follow-up to #596 / #245; makes the guidance in #196 actually work.

## Verification
Built locally and confirmed in the image:
- `which pip` → `/app/.venv/bin/pip`
- `pip install pytest-subtests` → `python -c 'import pytest_subtests'` succeeds (fails on v2.9.0)
- `molecule --version` still healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QiyKFy88rBg6pYtz4WZ9rP